### PR TITLE
Corrected the description for security-authorization-http-traffic lab

### DIFF
--- a/security-authorization-http-traffic/step6/text.md
+++ b/security-authorization-http-traffic/step6/text.md
@@ -1,6 +1,6 @@
 Create now an [AuthorizationPolicy](https://istio.io/latest/docs/reference/config/security/authorization-policy/)
 in the `default` namespace for the `notification-service` to enable incoming POST request 
-from sources with service account principal equal to `notification-service-policy`.
+from sources with service account principal equal to `cluster.local/ns/default/sa/booking-service-account`.
 
 The policy must **ALLOW** POST requests to any endpoint (i.e. no operation paths specified).
 


### PR DESCRIPTION
The security-authorization-http-traffic lab needed a minor correction in step 6.

The source service account principal is mentioned as `notification-service-policy` instead of `cluster.local/ns/default/sa/booking-service-account`.

This PR fixes it.

P.S. Thank you for these amazing labs to practice scenarios for Istio.