### PR TITLE
fix yahoo crypto links

### DIFF
--- a/egress-external-services-tls-origination/step2/text.md
+++ b/egress-external-services-tls-origination/step2/text.md
@@ -6,7 +6,7 @@ The **-L** parameter tells curl to automatically follow redirects:
 
 ```bash
 kubectl exec tester -c tester -- \
-  curl -sSL -o /dev/null -D - http://finance.yahoo.com/crypto | \
+  curl -sSL -o /dev/null -D - http://finance.yahoo.com/markets/crypto | \
   grep -e HTTP/ -e location; \
   echo;
 ```{{exec}}
@@ -14,7 +14,7 @@ kubectl exec tester -c tester -- \
 You should get a response with:
 ```text
 HTTP/1.1 301 Moved Permanently
-location: https://finance.yahoo.com/crypto
+location: https://finance.yahoo.com/markets/crypto
 HTTP/2 200
 ```
 

--- a/egress-external-services-tls-origination/step5/text.md
+++ b/egress-external-services-tls-origination/step5/text.md
@@ -4,7 +4,7 @@ works correctly by making a request to the external `finance.yahoo.com` service 
 
 ```bash
 kubectl exec tester -c tester -- \
-  curl -sS -o /dev/null -D - http://finance.yahoo.com/crypto | \
+  curl -sS -o /dev/null -D - http://finance.yahoo.com/markets/crypto | \
   grep -e HTTP/ -e location; \
   echo;
 ```{{exec}}

--- a/egress-gateways-tls-origination/step1/text.md
+++ b/egress-gateways-tls-origination/step1/text.md
@@ -21,7 +21,7 @@ on the original request made over HTTP.
 Test that you *cannot* reach `finance.yahoo.com` with the following:
 ```bash
 kubectl exec tester -c tester -- \
-  curl -sSL -o /dev/null -D - http://finance.yahoo.com/crypto | \
+  curl -sSL -o /dev/null -D - http://finance.yahoo.com/markets/crypto | \
   grep HTTP/
 ```{{exec}}
 

--- a/egress-gateways-tls-origination/step3/text.md
+++ b/egress-gateways-tls-origination/step3/text.md
@@ -3,7 +3,7 @@ to the `finance.yahoo.com` over HTTP.
 
 ```bash
 kubectl exec tester -c tester -- \
-  curl -sSL -o /dev/null -D - http://finance.yahoo.com/crypto | \
+  curl -sSL -o /dev/null -D - http://finance.yahoo.com/markets/crypto | \
   grep -e HTTP/ \
   -e location
 ```{{exec}}
@@ -11,10 +11,10 @@ kubectl exec tester -c tester -- \
 You should see the following result:
 ```text
 HTTP/1.1 301 Moved Permanently
-location: https://finance.yahoo.com/crypto
+location: https://finance.yahoo.com/markets/crypto
 HTTP/2 200
 ```
 
 This means that the service entry configuration works correctly, but also that `finance.yahoo.com` does not accept
 requests over HTTP and therefore the server requested *curl* client to resend the
-request over HTTPs on `https://finance.yahoo.com/crypto`.
+request over HTTPs on `https://finance.yahoo.com/markets/crypto`.

--- a/egress-gateways-tls-origination/step7/text.md
+++ b/egress-gateways-tls-origination/step7/text.md
@@ -3,7 +3,7 @@ to the `finance.yahoo.com` over HTTP:
 
 ```bash
 kubectl exec tester -c tester -- \
-  curl -sSL -o /dev/null -D - http://finance.yahoo.com/crypto | \
+  curl -sSL -o /dev/null -D - http://finance.yahoo.com/markets/crypto | \
   grep HTTP/
 ```{{exec}}
 
@@ -24,5 +24,5 @@ kubectl logs -l istio=egressgateway \
 
 You should see a log line similar to the following:
 ```text
-[2024-03-02T14:42:21.404Z] "GET /crypto HTTP/2" 200 - via_upstream - "-" 0 1035583 114 35 "X.Y.Z" "curl/7.88.1" "0ce1a5ba-99cf-9c8a-962d-bd9202f5522b" "finance.yahoo.com" "X.Y.Z:443" outbound|443||finance.yahoo.com X.Y.Z:33568 X.Y.Z:8080 X.Y.Z:36074 - -
+[2024-03-02T14:42:21.404Z] "GET /markets/crypto HTTP/2" 200 - via_upstream - "-" 0 1035583 114 35 "X.Y.Z" "curl/7.88.1" "0ce1a5ba-99cf-9c8a-962d-bd9202f5522b" "finance.yahoo.com" "X.Y.Z:443" outbound|443||finance.yahoo.com X.Y.Z:33568 X.Y.Z:8080 X.Y.Z:36074 - -
 ```


### PR DESCRIPTION
Fix http://finance.yahoo.com/crypto . It will automatically redirect to http://finance.yahoo.com/markets/crypto/all with browser but not for curl.