### PR TITLE
fix: pass environment variables correctly to external shell script

### DIFF
--- a/security-authorization-http-traffic/init/background.sh
+++ b/security-authorization-http-traffic/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below


### PR DESCRIPTION
Fixes an issue where the ISTIO_VERSION environment variable was not applied correctly 
during Istio installation via curl | sh. This caused the default version to be installed 
instead of the specified one.

The variable is now explicitly exported and passed inline to the shell script:
```
  export ISTIO_VERSION=1.18.2
  curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
```

This ensures that the correct Istio version is installed.