### PR TITLE
fix: updated passing variables issue

### DIFF
--- a/egress-external-services-tls-origination/init/background.sh
+++ b/egress-external-services-tls-origination/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/egress-gateways-tls-origination/init/background.sh
+++ b/egress-gateways-tls-origination/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/egress-gateways/init/background.sh
+++ b/egress-gateways/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/ingress-gateway-no-tsl-termination/init/background.sh
+++ b/ingress-gateway-no-tsl-termination/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/ingress-gateways-secure/init/background.sh
+++ b/ingress-gateways-secure/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/ingress-gateways/init/background.sh
+++ b/ingress-gateways/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/ingress-kubernetes/init/background.sh
+++ b/ingress-kubernetes/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/playground/init/background.sh
+++ b/playground/init/background.sh
@@ -10,7 +10,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/security-authentication-mtls/init/background.sh
+++ b/security-authentication-mtls/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/security-authorization-jwt-token/init/background.sh
+++ b/security-authorization-jwt-token/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/traffic-management-circuit-breaking/init/background.sh
+++ b/traffic-management-circuit-breaking/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/traffic-management-fault-injection/init/background.sh
+++ b/traffic-management-fault-injection/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/traffic-management-mirroring/init/background.sh
+++ b/traffic-management-mirroring/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/traffic-management-request-routing/init/background.sh
+++ b/traffic-management-request-routing/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below

--- a/traffic-management-traffic-shifting/init/background.sh
+++ b/traffic-management-traffic-shifting/init/background.sh
@@ -11,7 +11,7 @@ touch /ks/.k8sfinished
 
 # Install Istio
 export ISTIO_VERSION=1.18.2
-curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc
 export PATH=/root/istio-${ISTIO_VERSION}/bin:$PATH # set for istioctl below


### PR DESCRIPTION
Fixes an issue where the ISTIO_VERSION environment variable was not applied correctly
during Istio installation via curl | sh. This caused the default version to be installed
instead of the specified one.

The variable is now explicitly exported and passed inline to the shell script:
```bash
  export ISTIO_VERSION=1.18.2
  curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
```

This ensures that the correct Istio version is installed.

Related Commit
- https://github.com/lorenzo85/scenarios-ica/pull/9

This commit updates the full scenario set with the fix from the previous PR.
I had some personal time available, so I tested each scenario individually and am submitting this PR accordingly.

I'm a big fan of your ICA Scenario.

