### PR TITLE
Update Istio version to 1.26.0 across all scenario

### DIFF
--- a/egress-external-services-access/init/foreground.sh
+++ b/egress-external-services-access/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/egress-external-services-tls-origination/init/foreground.sh
+++ b/egress-external-services-tls-origination/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/egress-gateways-tls-origination/init/foreground.sh
+++ b/egress-gateways-tls-origination/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/egress-gateways/init/foreground.sh
+++ b/egress-gateways/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/ingress-gateway-no-tsl-termination/init/foreground.sh
+++ b/ingress-gateway-no-tsl-termination/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/ingress-gateways-secure/init/foreground.sh
+++ b/ingress-gateways-secure/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/ingress-gateways/init/background.sh
+++ b/ingress-gateways/init/background.sh
@@ -10,7 +10,7 @@ done
 touch /ks/.k8sfinished
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
 # Set PATH in .bashrc because no subshell can set parent environment variables
 echo "export PATH=/root/istio-${ISTIO_VERSION}/bin:\$PATH" >> ~/.bashrc

--- a/ingress-gateways/init/foreground.sh
+++ b/ingress-gateways/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/ingress-kubernetes/init/foreground.sh
+++ b/ingress-kubernetes/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/playground/init/foreground.sh
+++ b/playground/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/security-authentication-mtls/init/foreground.sh
+++ b/security-authentication-mtls/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/security-authorization-http-traffic/init/foreground.sh
+++ b/security-authorization-http-traffic/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/security-authorization-jwt-token/init/foreground.sh
+++ b/security-authorization-jwt-token/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/traffic-management-circuit-breaking/init/foreground.sh
+++ b/traffic-management-circuit-breaking/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/traffic-management-fault-injection/init/foreground.sh
+++ b/traffic-management-fault-injection/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/traffic-management-mirroring/init/foreground.sh
+++ b/traffic-management-mirroring/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/traffic-management-request-routing/init/foreground.sh
+++ b/traffic-management-request-routing/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables

--- a/traffic-management-traffic-shifting/init/foreground.sh
+++ b/traffic-management-traffic-shifting/init/foreground.sh
@@ -2,7 +2,7 @@ FILE=/ks/wait-background.sh; while ! test -f ${FILE}; do clear; sleep 0.1; done;
 bash ${FILE}
 
 # Install Istio
-export ISTIO_VERSION=1.18.2
+export ISTIO_VERSION=1.26.0
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION TARGET_ARCH=x86_64 sh -
 
 # Set PATH in .bashrc because no subshell can set parent environment variables


### PR DESCRIPTION
Summary:
  This PR upgrades the Istio version from 1.18.2 to 1.26.0 in the initialization scripts (foreground.sh and background.sh) for all training scenarios. This ensures that the labs are running on a modern version of Istio.

  Changes:
   - Updated export ISTIO_VERSION=1.26.0 in all init/foreground.sh files.
   - Updated export ISTIO_VERSION=1.26.0 in ingress-gateways/init/background.sh.

  Affected Scenarios:
   - All 17 scenarios listed in structure.json.

  Verification:
   - Verified that the version string was updated consistently across all scenario directories.
   - Confirmed the download URL logic https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION ... remains valid for the new version.
